### PR TITLE
Fixed wrong icon class from 'caret-down' to 'chevron-down'

### DIFF
--- a/app/views/tabulatr/_tabulatr_batch_actions_menu.html.slim
+++ b/app/views/tabulatr/_tabulatr_batch_actions_menu.html.slim
@@ -24,7 +24,7 @@
   .dropdown
     a.btn.btn-default data-toggle="dropdown" href="#"
       i.icon-cog.glyphicon.glyphicon-cog.fa.fa-cog'
-      i.icon-caret-down.glyphicon.glyphicon-caret-down.fa.fa-caret-down
+      i.icon-caret-down.glyphicon.glyphicon-chevron-down.fa.fa-caret-down
     ul.dropdown-menu role="menu" aria-labelledby="dLabel"
       - table_options[:batch_actions].each do |key, label|
         li

--- a/app/views/tabulatr/_tabulatr_filter_menu.html.slim
+++ b/app/views/tabulatr/_tabulatr_filter_menu.html.slim
@@ -23,7 +23,7 @@
   .dropdown
     a.btn.btn-default data-toggle="dropdown" href="#"
       i.icon-filter.glyphicon.glyphicon-filter.fa.fa-filter'
-      i.icon-caret-down.glyphicon.glyphicon-caret-down.fa.fa-caret-down
+      i.icon-caret-down.glyphicon.glyphicon-chevron-down.fa.fa-caret-down
     ul.dropdown-menu role="menu" aria-labelledby="dLabel"
       - columns.select(&:filter).each do |column|
         li


### PR DESCRIPTION
The glyphicon  'glyphicon glyphicon-caret-down' doesn't exist. This pr fixes the class for the icons.
