### PR TITLE
Non-translated Von & Bis in custom dates

### DIFF
--- a/app/views/tabulatr/_tabulatr_filter_dialog.html.slim
+++ b/app/views/tabulatr/_tabulatr_filter_dialog.html.slim
@@ -77,17 +77,17 @@
                       option value="last_7_days"= I18n.t("tabulatr.date_filter.last_7_days")
                       option value="this_month"= I18n.t("tabulatr.date_filter.this_month")
                       option value="last_30_days"= I18n.t("tabulatr.date_filter.last_30_days")
-                      option value="from_to"= I18n.t("tabulatr.date_filter.from_to")
+                      option value="from_to"= "#{I18n.t('tabulatr.date_filter.from')} - #{I18n.t('tabulatr.date_filter.to')}"
                     .row.from_to.hidden
                       .col-xs-6
                         .control-group
                           label.control-label for="#{formatted_name}_#{name}_filter_from"
-                            = "Von"
+                            = I18n.t("tabulatr.date_filter.from")
                           input.tabulatr_filter.form-control.date-picker.hidden.from_to type="text" id="#{formatted_name}_#{name}_filter_from" name="#{iname}[date][from]"
                       .col-xs-6
                         .control-group
                           label.control-label for="#{formatted_name}_#{name}_filter_from"
-                            = "Bis"
+                            = I18n.t("tabulatr.date_filter.to")
                           input.tabulatr_filter.form-control.date-picker.from_to.hidden type="text" id="#{formatted_name}_#{name}_filter_to" name="#{iname}[date][to]"
                   - elsif column.filter == :enum
                     select.form-control name=iname data-tabulatr-attribute=name

--- a/lib/tabulatr/generators/tabulatr/templates/tabulatr.yml
+++ b/lib/tabulatr/generators/tabulatr/templates/tabulatr.yml
@@ -14,7 +14,8 @@ en:
       last_7_days: Last 7 Days
       this_month: This Month
       last_30_days: Last 30 Days
-      from_to: From - To
+      from: From
+      to: To
     boolean_filter:
       both: All
       'yes': Yes
@@ -39,7 +40,8 @@ de:
       last_7_days: Letzte 7 Tage
       this_month: Dieser Monat
       last_30_days: Letzte 30 Tage
-      from_to: Von - Bis
+      from: Von
+      to: Bis
     boolean_filter:
       both: Alle
       'yes': Ja

--- a/spec/dummy/config/locales/tabulatr.yml
+++ b/spec/dummy/config/locales/tabulatr.yml
@@ -14,7 +14,8 @@ en:
       last_7_days: Last 7 Days
       this_month: This Month
       last_30_days: Last 30 Days
-      from_to: From - To
+      from: From
+      to: To
     boolean_filter:
       both: All
       'yes': Yes
@@ -38,7 +39,8 @@ de:
       last_7_days: Letzte 7 Tage
       this_month: Dieser Monat
       last_30_days: Letzte 30 Tage
-      from_to: Von - Bis
+      from: Von
+      to: Bis
     boolean_filter:
       both: Alle
       'yes': Ja


### PR DESCRIPTION
There are non-translated strings for custom dates. Instead of adding more translations, I just split existing one hard-coding dash.