### PR TITLE
Make @controller accessible for custom filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  -  2.0.0
-  -  2.1.0
+#  -  2.1.10
+  -  2.2.6
+  -  2.3.3
+#  -  2.4.0 # wait for json > 1.8.3
   -  jruby-9.1.5.0
 script: "bundle exec rspec spec"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 rvm:
   -  2.0.0
   -  2.1.0
-  -  jruby
-matrix:
-  allow_failures:
-    - rvm: jruby
+  -  jruby-9.1.5.0
 script: "bundle exec rspec spec"
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,12 @@ end
 
 
 group :development, :test do
-  gem 'sqlite3', :require => 'sqlite3'
+  if defined?(JRUBY_VERSION)
+    gem 'activerecord-jdbc-adapter'
+    gem 'jdbc-sqlite3'
+  else
+    gem 'sqlite3'
+  end
   gem 'minitest'
   gem 'launchy'
   gem 'database_cleaner', '< 1.1.0'

--- a/app/assets/javascripts/tabulatr/_tabulatr.js
+++ b/app/assets/javascripts/tabulatr/_tabulatr.js
@@ -75,6 +75,13 @@ Tabulatr.prototype = {
   },
 
   loadDataFromServer: function(hash){
+    var data = this.getDataForAjax(hash)
+    // deparse existing params http://stackoverflow.com/a/8649003/673826
+    var search = location.search.substring(1);
+    if (search.length){
+      var query = JSON.parse('{"' + decodeURI(search).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
+      data = $.extend(query, data);
+    }
     $.ajax({
       context: this,
       type: 'GET',
@@ -82,7 +89,7 @@ Tabulatr.prototype = {
       accepts: {
         json: 'application/json'
       },
-      data: this.getDataForAjax(hash),
+      data: data,
       success: this.handleResponse,
       complete: this.hideLoadingSpinner,
       error: this.handleError

--- a/lib/tabulatr/data/data.rb
+++ b/lib/tabulatr/data/data.rb
@@ -43,7 +43,7 @@ class Tabulatr::Data
   def data_for_table(params, locals: {}, controller: nil, &block)
 
     @batch_actions = block if block_given?
-
+    @controller = controller
 
     # count
     total = @relation.count

--- a/lib/tabulatr/data/filtering.rb
+++ b/lib/tabulatr/data/filtering.rb
@@ -106,7 +106,7 @@ module Tabulatr::Data::Filtering
   end
 
   def apply_custom_filter(filter, value)
-    filter_result = filter.block.(@relation, value)
+    filter_result = self.instance_exec @relation, value, &filter.block
     handle_search_result(filter_result)
   end
 

--- a/spec/dummy/app/controllers/vendors_controller.rb
+++ b/spec/dummy/app/controllers/vendors_controller.rb
@@ -1,5 +1,8 @@
 class VendorsController < ApplicationController
+  attr_reader :split
+
   def index
+     @split = params[:split] && params[:split].to_f || 100
      tabulatr_for Vendor
   end
 end

--- a/spec/dummy/app/tabulatr_data/vendor_tabulatr_data.rb
+++ b/spec/dummy/app/tabulatr_data/vendor_tabulatr_data.rb
@@ -7,9 +7,9 @@ class VendorTabulatrData < Tabulatr::Data
   filter :product_price_range do |relation, value|
     relation = relation.joins(:products)
     if value == 'low'
-      relation.group("vendors.id").having('AVG(products.price) <= 100')
+      relation.group("vendors.id").having('AVG(products.price) <= ?', @controller.split)
     elsif value == 'high'
-      relation.group("vendors.id").having('AVG(products.price) > 100')
+      relation.group("vendors.id").having('AVG(products.price) > ?', @controller.split)
     end
   end
 end

--- a/spec/dummy/app/views/tabulatr/filter/_product_price_range.html.slim
+++ b/spec/dummy/app/views/tabulatr/filter/_product_price_range.html.slim
@@ -4,6 +4,6 @@
   select.form-control.no-chosen id=input_id name=input_name
     option= I18n.t("tabulatr.date_filter.none")
     option value="low"
-      | <= 100 Euro
+      | Cheap
     option value="high"
-      | > 100 Euro
+      | Expensive

--- a/spec/features/tabulatrs_spec.rb
+++ b/spec/features/tabulatrs_spec.rb
@@ -254,7 +254,8 @@ feature "Tabulatr" do
       within(".tabulatr_filter_form") do
         select("Cheap", from: "vendor_filter[product_price_range]")
       end
-      expect(page).to have_css(".tabulatr_table tbody tr", count: 0)
+#      wait_for_ajax
+      expect(page).to have_css(".tabulatr_table tbody tr", count: 0, wait: 10)
     end
   end
 

--- a/spec/features/tabulatrs_spec.rb
+++ b/spec/features/tabulatrs_spec.rb
@@ -228,15 +228,33 @@ feature "Tabulatr" do
       expect(page).to have_css(".tabulatr_table tbody tr", count: 2)
       click_link 'Filter'
       within(".tabulatr_filter_form") do
-        select("> 100 Euro", from: "vendor_filter[product_price_range]")
+        select("Expensive", from: "vendor_filter[product_price_range]")
       end
       expect(page).to have_css(".tabulatr_table tbody tr", count: 1)
       expect(page).to have_css('.tabulatr_table tbody td', text: @vendor2.name)
       within(".tabulatr_filter_form") do
-        select("<= 100 Euro", from: "vendor_filter[product_price_range]")
+        select("Cheap", from: "vendor_filter[product_price_range]")
       end
       expect(page).to have_css(".tabulatr_table tbody tr", count: 1)
       expect(page).to have_css('.tabulatr_table tbody td', text: @vendor1.name)
+    end
+
+    scenario 'custom split filters', js: true do
+      Product.create!([{title: 'foo', price: 7.5, vendor: @vendor1}, {title: 'bar', price: 90, vendor: @vendor1}])
+      Product.create!([{title: 'baz', price: 125, vendor: @vendor2}, {title: 'fubar', price: 133.3, vendor: @vendor2}, {title: 'fiz', price: 97, vendor: @vendor2}])
+      visit vendors_path + '?split=5'
+      expect(page).to have_css(".tabulatr_table tbody tr", count: 2)
+      click_link 'Filter'
+      within(".tabulatr_filter_form") do
+        select("Expensive", from: "vendor_filter[product_price_range]")
+      end
+      expect(page).to have_css(".tabulatr_table tbody tr", count: 2)
+      expect(page).to have_css('.tabulatr_table tbody td', text: @vendor1.name)
+      expect(page).to have_css('.tabulatr_table tbody td', text: @vendor2.name)
+      within(".tabulatr_filter_form") do
+        select("Cheap", from: "vendor_filter[product_price_range]")
+      end
+      expect(page).to have_css(".tabulatr_table tbody tr", count: 0)
     end
   end
 

--- a/tabulatr.gemspec
+++ b/tabulatr.gemspec
@@ -28,7 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency('tilt', '~> 1.4', '>= 1.4.1')
   s.add_dependency('font-awesome-rails', '>= 4.0')
   s.add_development_dependency('rspec-rails', '~> 3.1.0')
-  s.add_development_dependency('capybara', '2.4.3')
-  s.add_development_dependency('mime-types', '~> 1.25.1')
-  s.add_development_dependency('nokogiri', '~> 1.6.8')
+  s.add_development_dependency('capybara', '~> 2.4.1')
 end

--- a/tabulatr.gemspec
+++ b/tabulatr.gemspec
@@ -28,5 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('tilt', '~> 1.4', '>= 1.4.1')
   s.add_dependency('font-awesome-rails', '>= 4.0')
   s.add_development_dependency('rspec-rails', '~> 3.1.0')
-  s.add_development_dependency('capybara', '~> 2.4.1')
+  s.add_development_dependency('capybara', '2.4.3')
+  s.add_development_dependency('mime-types', '~> 1.25.1')
+  s.add_development_dependency('nokogiri', '~> 1.6.8')
 end


### PR DESCRIPTION
This addresses [an issue](https://github.com/metaminded/tabulatr2/issues/49#issuecomment-268139918) brought in #49.
Perhaps this needs some tests to go with. I see [dummy app has a custom filter](https://github.com/metaminded/tabulatr2/blob/master/spec/dummy/app/tabulatr_data/vendor_tabulatr_data.rb) for low/high pricing. [~This is not currently tested(?).~](https://github.com/metaminded/tabulatr2/blob/master/spec/features/tabulatrs_spec.rb#L224) This might be an okay candidate to extend for what is considered an average by a user defaulting to 100, if overridden by user. However, I'm not good with RSpecs on how to mimic this.