### PR TITLE
submit filters on 'dp.change' Event

### DIFF
--- a/app/assets/javascripts/tabulatr/_events.js
+++ b/app/assets/javascripts/tabulatr/_events.js
@@ -86,6 +86,10 @@ function tabulatrInitialize() {
     $(this).parents('form.tabulatr_filter_form').submit();
   });
 
+  $('form.tabulatr_filter_form input').on('dp.change', function(){
+    $(this).parents('form.tabulatr_filter_form').submit();
+  });
+
   $('form.tabulatr_filter_form').submit(function(){
     var tableId = $(this).data('table');
     var table_obj;

--- a/lib/tabulatr/version.rb
+++ b/lib/tabulatr/version.rb
@@ -22,5 +22,5 @@
 #++
 
 module Tabulatr
-  VERSION = "0.9.42"
+  VERSION = "0.9.43"
 end


### PR DESCRIPTION
Bootstrap3 datetimpicker prevents the date inputs from emitting a change
Event. We can fix this by additionally listening to their custom
'dp.change' Event

see https://github.com/Eonasdan/bootstrap-datetimepicker/blob/25c11d79e614bc6463a87c3dd9cbf8280422e006/src/js/bootstrap-datetimepicker.js#L850